### PR TITLE
Added custom target release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # ocp4upc
+
 OCP4 Upgrade Paths Checker
 ## Description
 This script generates a graphical output of the possible minor upgrade paths using production-ready OpenShift 4 **stable** and **fast** [channels](https://docs.openshift.com/container-platform/4.3/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor).
 ## Usage
+
 ~~~
 $ ./ocp4upc.sh source_version [arch]
 ~~~
+
 ## Example
 ~~~
 $ ./ocp4upc.sh 4.2.18
@@ -15,10 +18,17 @@ $ ./ocp4upc.sh 4.2.18
 [INFO] Result exported as 'fast-4.3.svg'
 ~~~
 ![fast-4.3 example](https://github.com/pamoedom/ocp4upc/blob/master/examples/fast-4.3.png)
-## Dependencies
+
+If you want to specify a custom minor version you have to define the `TRG` variable, the following command will get all the possible upgrade path within the `4.2` minor version:
+
+~~~
+$ TRG="4.2" ./ocp4upc.sh 4.2.7
+~~~
+
+# Dependencies
 - `curl` <https://curl.haxx.se/>
 - `jq` <http://stedolan.github.io/jq/>
 - `dot` <http://www.graphviz.org/>
-- `bc` <http://www.gnu.org/software/bc/>
+- `bc`<https://www.gnu.org/software/bc/>
 ## Additional notes
 For more info on how to perform a minor upgrade using `oc` cli, please refer to this [solution](https://access.redhat.com/solutions/4606811) (subscription needed).

--- a/ocp4upc.sh
+++ b/ocp4upc.sh
@@ -48,7 +48,7 @@ REL='https://quay.io/api/v1/repository/openshift-release-dev/ocp-release'
 VER=$1
 MAJ=`echo ${VER} | cut -d. -f1`
 MIN=`echo ${VER} | cut -d. -f2`
-TRG="${MAJ}.`echo ${MIN}+1 | bc`"
+[[ "$TRG" == "" ]] && TRG="${MAJ}.`echo ${MIN}+1 | bc`"
 EDG="blue"
 ORG="salmon"
 DST="yellowgreen"
@@ -60,6 +60,8 @@ CHA=(stable fast)
 REQ=(curl jq dot bc)
 RES=()
 LTS=""
+
+cout "INFO" "Target release is $TRG"
 
 #PREREQUISITES
 


### PR DESCRIPTION
Added the possibility to define a custom minor version as target, in this way one can print the graph of the available upgrades within the same minor version.